### PR TITLE
Fix layout class bug and update favorites utility

### DIFF
--- a/pages/_responsive-layout.tsx
+++ b/pages/_responsive-layout.tsx
@@ -30,9 +30,7 @@ const ResponsiveLayout: React.FC<IResponsiveLayoutProps> = ({
   return (
     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 lg:grid-cols-12 2xl:flex 2xl:justify-center 2xl:gap-x-8 gap-4 p-4 md:p-6 xl:p-8 min-h-screen">
       {/* Left Spacer */}
-      <div
-        className={`hidden xl:block xl:col-span-1 2xl:col-span-1 2xl:hidden'}`}
-      />
+      <div className="hidden xl:block xl:col-span-1 2xl:col-span-1 2xl:hidden" />
 
       {/* Main Content */}
       <main
@@ -51,9 +49,7 @@ const ResponsiveLayout: React.FC<IResponsiveLayoutProps> = ({
       )}
 
       {/* Right Spacer */}
-      <div
-        className={`hidden xl:block xl:col-span-1 2xl:col-span-1 2xl:hiddens`}
-      />
+      <div className="hidden xl:block xl:col-span-1 2xl:col-span-1 2xl:hidden" />
     </div>
   );
 };

--- a/utils/favorites.ts
+++ b/utils/favorites.ts
@@ -1,5 +1,5 @@
 export const setupFavorites = (setFavorites) => {
-  if (window && window.localStorage) {
+  if (typeof window !== 'undefined' && window.localStorage) {
     const favorites = JSON.parse(localStorage.getItem('favorites')) || [];
     setFavorites(favorites);
   }


### PR DESCRIPTION
## Summary
- correct class names for layout spacer divs
- guard against undefined `window` in favorites utility

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841a98124f0832891853edf7f489599